### PR TITLE
Correct cheatcodes directory name

### DIFF
--- a/proprietary/system/bin/anxfeatures
+++ b/proprietary/system/bin/anxfeatures
@@ -1,6 +1,6 @@
 #!/system/bin/sh
 
-if [ ! -f "/sdcard/.MiuiCamera/.check" ]; then
+if [ ! -f "/sdcard/.ANXCamera/.check" ]; then
     rm -rf /sdcard/.ANXCamera/
     mkdir -p /sdcard/.ANXCamera/cheatcodes/
     cp -R /system/etc/ANXCamera/cheatcodes/* /sdcard/.ANXCamera/cheatcodes/


### PR DESCRIPTION
I noticed the .ANXCamera directory was getting replaced every few seconds.

Corrected the directory name in the IF statement.